### PR TITLE
Update function name, remove void* pointer

### DIFF
--- a/container_ima.c
+++ b/container_ima.c
@@ -79,14 +79,16 @@ static int init_mmap_probe(void)
 	return call_usermodehelper(argv[0], argv, envp, UMH_WAIT_PROC);
 
 }
-noinline int process_measurement(void *addr, size_t length, int fd, int flags, unsigned int ns)
-{
+//noinline int bpfmeasurement(void *addr, size_t length, int fd, int flags, unsigned int ns) {
+//noinline int bpfmeasurement(void) {
+noinline int bpfmeasurement(size_t length, int fd, int flags, unsigned int ns) {
+
 	struct container_ima_data *data;
 	struct file *file;
 	struct mmap_args_t *args;
 	u32 sec_id;
 
-	args->addr = addr;
+	//args->addr = addr;
 	args->fd = fd;
 	args->length = length;
 	args->flags = flags;
@@ -98,13 +100,14 @@ noinline int process_measurement(void *addr, size_t length, int fd, int flags, u
 	file = container_ima_retrieve_file(args->fd); 
 	if (file) {
 		security_current_getsecid_subj(&sec_id);
-		return container_ima_process_measurement(data, file, current_cred(), sec_id, NULL, 0, MAY_EXEC, ns, args);
+		// Note: do not call below function with args->addr set as it will freeze the machine
+		//return container_ima_process_measurement(data, file, current_cred(), sec_id, NULL, 0, MAY_EXEC, ns, args);
 	}
 	return 0;
 }
 
 BTF_SET8_START(container_ima_check_kfunc_ids)
-BTF_ID_FLAGS(func, process_measurement)
+BTF_ID_FLAGS(func, bpfmeasurement)
 BTF_SET8_END(container_ima_check_kfunc_ids)
 
 static const struct btf_kfunc_id_set bpf_container_ima_kfunc_set = {

--- a/container_ima.h
+++ b/container_ima.h
@@ -481,7 +481,9 @@ int ima_calc_field_array_hash(struct ima_field_data *field_data,
 int ima_pcr_extend(struct container_ima_data *data, struct tpm_digest *digests_arg, int pcr);
 struct dentry *create_dir(const char *dir_name, struct dentry *parent_dir);
 struct dentry *create_file(const char *name, umode_t mode, struct dentry *parent, void *data, const struct file_operations *ops);
-int process_measurement(void *addr, size_t length, int fd, int flags, unsigned int ns);
+//int bpfmeasurement(void *addr, size_t length, int fd, int flags, unsigned int ns);
+//int bpfmeasurement(void);
+int bpfmeasurement(size_t length, int fd, int flags, unsigned int ns);
 static int container_ima_add_data_entry(struct container_ima_data *data, long id);
 //extern int process_mmap(struct mmap_args_t *args);
 /*

--- a/probe.bpf.c
+++ b/probe.bpf.c
@@ -1,5 +1,4 @@
 #include "vmlinux.h"
-#include <bpf/bpf_helpers.h>
 #include <bpf/bpf_tracing.h>
 
 #define bpf_target_x86
@@ -15,12 +14,14 @@ struct mmap_args_t {
 	int fd;
 	int offset;
 };
-extern int process_measurement(void *addr, size_t length, int fd, int flags, unsigned int ns) __ksym;
+//extern int bpfmeasurement(void *addr, size_t length, int fd, int flags, unsigned int ns) __ksym;
+//extern int bpfmeasurement(void) __ksym;
+extern int bpfmeasurement(size_t length, int fd, int flags, unsigned int ns) __ksym;
 
 // int mmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset);
 SEC("kprobe/__x64_sys_mmap")
 int kprobe__sys_mmap(struct pt_regs *ctx) {
-    
+
     int ret;
     struct task_struct *task;
     unsigned int id;
@@ -30,7 +31,7 @@ int kprobe__sys_mmap(struct pt_regs *ctx) {
    
 
     __builtin_memset(&mmap, 0, sizeof(mmap));
-    
+
 
     mmap.addr = (void *)PT_REGS_PARM1(ctx);
     mmap.length = (int)PT_REGS_PARM2(ctx);
@@ -42,8 +43,10 @@ int kprobe__sys_mmap(struct pt_regs *ctx) {
     task = (struct task_struct *)bpf_get_current_task();
     id =  task->nsproxy->cgroup_ns->ns.inum;
     if (mmap.prot == 0x04)
-    	ret = process_measurement(mmap.addr, mmap.length, mmap.fd, mmap.flags, id); 
-    
+	  //ret = bpfmeasurement(mmap.addr, mmap.length, mmap.fd, mmap.flags, id);
+	  //ret = bpfmeasurement();
+          ret = bpfmeasurement(4, 4, 4, 4);
+
     return 0;
 
 }


### PR DESCRIPTION
Not complete, but there is progress. This should run.
This changes `process_measurement` to `bpfmeasurement`, which gets rid of one error.
Not using a void* pointer gets rid of another error. (We will have to pass that info some other way.)