### PR TITLE
Ubuntu & Debian support, documentation and thread-safe memory allocation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,9 @@
 # 	Builds kernel module and eBPF program
 #
 obj-m += container_ima.o 
+ifeq ($(shell expr match `uname -r` ".*container.*" \> 0), 1)
+	ccflags-y := -D_LSMSTACKING=1
+endif
 all: kmod $(APPS)
 
 # Libbpf Makefile from libbpf-bootstrap

--- a/README.md
+++ b/README.md
@@ -30,13 +30,45 @@ Insert eBPF probe \
 `sudo ./probe`
 
 ### Ubuntu
-Note: For ubuntu, the kernel must be compiled with bpf enabled in `CONFIG_LSM`.
+Prerequisite: Upgrade the kernel to 6.2.x (or newer) and enable bpf in CONFIG_LSM. \
+Disclaimer: Be aware that packages from universe or multiverse will be installed along with linux-image-unsigned-6.2.0-*'s build dependencies. Those packages do not receive any reviews or updates from the Ubuntu security team. Alternatively, you may compile a kernel from source, which does not require any dependencies from universe or multiverse. \
+For Ubuntu 22.04LTS: \
+`apt-get update` \
+Note: make sure deb-src sources are not commented out in /etc/apt/sources.list. \
+`apt-cache search linux-image-unsigned-6.2.0 generic` \
+`apt-get build-dep linux-image-unsigned-6.2.0-31-generic` \
+Note: -31 is the latest unsigned-6.2.0 generic at the time of writing. \
+`apt-get source linux-image-unsigned-6.2.0-31-generic` \
+`cd /usr/src/linux-hwe-6.2-6.2.0` \
+`make olddefconfig` \
+`grep -e "^CONFIG_LSM=.*bpf.*" .config || sed -i 's/^CONFIG_LSM="\(.*\)"/CONFIG_LSM="\1,bpf"/' .config` \
+`sed -i 's/^EXTRAVERSION.*/EXTRAVERSION = -containerima/' Makefile` \
+``make -j`nproc` && make modules_install && make install`` \
+`sed -i 's/^GRUB_CMDLINE_LINUX_DEFAULT=""/GRUB_CMDLINE_LINUX_DEFAULT="lsm=apparmor,integrity,bpf ima_apparise=log ima_hash=sha256"/' /etc/default/grub` \
+Note: integrity and bpf LSMs should be initialized at boot. Note that this overrides CONFIG_LSM. \
+`update-grub` \
+Optional: since 6.0.3 the i_version counter is always enabled on ext4. \
+`sed -i 's/\(\/ ext4 defaults\)/\/ ext4 noatime,iversion/' /etc/fstab` \
+`shutdown -r now`
 
-Update \
+### Debian
+Debian 12 (bookworm) follows the same logic as Ubuntu (see above): \
+`apt-get update` \
+`cd /usr/src` \
+`apt-get source linux-image-6.4.0-0.deb12.2-amd64-unsigned` \
+`cd /usr/src/linux-6.4.4` \
+`make olddefconfig` \
+`sed -i 's/^CONFIG_LSM="\(.*\)"/CONFIG_LSM="\1,bpf"/' .config` \
+``make -j`nproc` && make modules_install && make install`` \
+`sed -i 's/^GRUB_CMDLINE_LINUX_DEFAULT=""/GRUB_CMDLINE_LINUX_DEFAULT="lsm=apparmor,integrity,bpf ima_apparise=log ima_hash=sha256"/' /etc/default/grub` \
+`update-grub` \
+Note: Debian kernels still define void security_current_getsecid_subj(u32 *secid) so you don't need to modify EXTRAVERSION.
+
+Continue with the installation of container-ima: \
 `sudo apt update` \
 Install dependencies \
-`sudo apt install llvm libelf-dev libssl-dev gcc-12 git clang dwarves` \
-Install kernel headers \
+`sudo apt install llvm libelf-dev libssl-dev gcc-12 git clang dwarves libc6-dev-i386` \
+Install kernel headers (you may skip this section if you have just installed a new kernel) \
 `sudo apt install linux-headers-$(uname -r)` \
 Clone repository \
 `git clone https://github.com/avery-blanchard/container-ima/` \

--- a/container_ima.c
+++ b/container_ima.c
@@ -127,26 +127,25 @@ noinline int ima_store_measurement(struct ima_max_digest_data *hash,
 noinline int ima_file_measure(struct file *file, unsigned int ns, 
 		struct ima_template_desc *desc)
 {
-        int check, length, hash_algo;
-	char buf[64];
+	int check, length, hash_algo;
+	char *buf = vmalloc(IMA_MAX_DIGEST_SIZE);
 	char *extend;
 	char *path;
-	char filename[128];
-	char ns_buf[128];
-        struct ima_max_digest_data hash;
-
+	char *ns_buf = vmalloc(16);
+	char *filename = vmalloc(PATH_MAX);
+	struct ima_max_digest_data hash;
 
 	/* Measure file */
         hash_algo = ima_file_hash(file, buf, sizeof(buf));
 
 	path = ima_d_path(&file->f_path, &path, filename);
 	if (!path) {
-		return 0;
+		goto end;
 	}
 	
 	/* Catch all for policy errors, todo */
 	if (path[0] != '/')
-		return 0;
+		goto end;
 
 	sprintf(ns_buf, "%u", ns);
 	sprintf(filename, "%u:%s", ns, path);
@@ -165,11 +164,15 @@ noinline int ima_file_measure(struct file *file, unsigned int ns,
 	 * Hash the concatonated string */	
 	check = ima_calc_buffer_hash(extend, sizeof(extend), &hash.hdr);
 	if (check < 0)
-		return 0;
+		goto end;
 	
 	check = ima_store_measurement(&hash, file, filename, length, 
 			desc, hash_algo);
 
+end:
+	vfree(buf);
+	vfree(filename);
+	vfree(ns_buf);
 	return 0;
 }
 
@@ -184,12 +187,15 @@ noinline int ima_file_measure(struct file *file, unsigned int ns,
  */
 noinline int bpf_process_measurement(void *mem, int mem__sz)
 {
-
 	int ret, action, pcr;
 	struct inode *inode;
 	struct mnt_idmap *idmap;
 	const struct cred *cred;
+#ifdef _LSMSTACKING
+	struct lsmblob blob;
+#else
 	u32 secid;
+#endif /* _LSMSTACKING */
 	struct ima_template_desc *desc = NULL;
 	unsigned int allowed_algos = 0;
 	struct ebpf_data *data = (struct ebpf_data *) mem;
@@ -203,8 +209,11 @@ noinline int bpf_process_measurement(void *mem, int mem__sz)
 	if (!S_ISREG(inode->i_mode))
                 return 0;
 
-
+#ifdef _LSMSTACKING
+	security_current_getsecid_subj(&blob);
+#else
 	security_current_getsecid_subj(&secid);
+#endif /* _LSMSTACKING */
 
 	cred = current_cred();
 	if (!cred)
@@ -214,9 +223,15 @@ noinline int bpf_process_measurement(void *mem, int mem__sz)
 
 	/* Get action form IMA policy */
 	pcr = 10;
+#ifdef _LSMSTACKING
+	action = ima_get_action(idmap, inode, cred, blob.secid[0], 
+					MAY_EXEC, MMAP_CHECK, &pcr, &desc, 
+					NULL, &allowed_algos);
+#else
 	action = ima_get_action(idmap, inode, cred, secid, 
-			MAY_EXEC, MMAP_CHECK, &pcr, &desc, 
-			NULL, &allowed_algos);
+					MAY_EXEC, MMAP_CHECK, &pcr, &desc, 
+					NULL, &allowed_algos);
+#endif /* _LSMSTACKING */
 	if (!action)  
 		return 0;
 	


### PR DESCRIPTION
* Adds Ubuntu and Debian installation documentation.
* Make memory allocations thread-safe in the kernel module.
* Adds support for official Canonical Linux kernels with Canonical patches, including LSM_STACKING.
* Adjust various buffer sizes in ima_file_measurement().